### PR TITLE
requests 2.27.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "requests" %}
-{% set version = "2.26.0" %}
+{% set version = "2.27.1" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/requests-{{ version }}.tar.gz
-  sha256: b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7
+  sha256: 68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,20 +17,23 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
     - certifi >=2017.4.17
-    # no longer required, but optional: https://github.com/psf/requests/pull/5797
-    # - chardet >=3.0.2,<5
     - charset-normalizer >=2.0.0,<2.1.0
     - idna >=2.5,<4
     - urllib3 >=1.21.1,<1.27
+    # no longer required for python 3.6+, but optional: https://github.com/psf/requests/pull/5797
+    # - chardet >=3.0.2,<5
 
 test:
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
   imports:
@@ -39,6 +42,7 @@ test:
 about:
   home: http://python-requests.org
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   summary: Requests is an elegant and simple HTTP library for Python, built with ♥.
   description: |


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/psf/requests/issues
Changelog: https://docs.python-requests.org/en/latest/community/updates/#release-history 
Upstream license:  License file:  https://github.com/psf/requests/blob/master/LICENSE
Upstream setup.py:  https://github.com/psf/requests/blob/v2.27.1/setup.py

Actions:
1. Add missing packages: `setuptools`, `wheel`
2. Fix python in host
3. Add python <3.10 in test/requires
4. Add license_family

Result:
- all-succeeded

