### PR TITLE
Update to 2.29.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "requests" %}
-{% set version = "2.28.1" %}
-{% set hash = "7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983" %}
-{% set build_number = "1" %}
+{% set version = "2.29.0" %}
+{% set hash = "f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059" %}
+{% set build_number = "0" %}
 
 package:
   name: {{ name|lower }}
@@ -13,7 +13,7 @@ source:
 
 build:
   number: {{ build_number }}
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<37]
 
 
@@ -26,7 +26,7 @@ requirements:
   run:
     - python
     - certifi >=2017.4.17
-    - charset-normalizer >=2,<3
+    - charset-normalizer >=2,<4
     - idna >=2.5,<4
     - urllib3 >=1.21.1,<1.27
   # https://github.com/psf/requests/blob/da9996fe4dc63356e9467d0a5e10df3d89a8528e/requests/__init__.py#L103-L115


### PR DESCRIPTION
Update to 2.29.0

Upstream diff: https://github.com/psf/requests/compare/v2.28.1..v2.29.0

Changes:
* Reset build number to zero
* Add `--no-build-isolation --no-deps` flags to pip install command
* Bumped maximum allowed version of `charset-normalizer` to 4 based on upstream