### PR TITLE
requests 2.31.0 fix

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,1 @@
 aggregate_branch: 3.12
-
-channels:
-  lp_test: snowflake
-
-upload_without_merge: true

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,6 @@
 aggregate_branch: 3.12
+
+channels:
+  lp_test: snowflake
+
+upload_without_merge: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,11 +35,11 @@ test:
     - requests
   requires:
     - pip
-    - conda                                            # [py<312] temporary for the 3.12 buildout
+    - conda
   commands:
     - pip check
     # to make sure this doesn't break conda at the very least
-    - conda create -v --dry-run -n requests-test numpy # [py<312] temporary for the 3.12 buildout
+    - conda create -v --dry-run -n requests-test numpy
 
 about:
   home: https://requests.readthedocs.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,5 @@
 {% set name = "requests" %}
 {% set version = "2.31.0" %}
-{% set hash = "942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1" %}
-{% set build_number = "0" %}
 
 package:
   name: {{ name|lower }}
@@ -9,13 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/requests-{{ version }}.tar.gz
-  sha256: {{ hash }}
+  sha256: 942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
 
 build:
-  number: {{ build_number }}
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<37]
-
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -25,16 +21,18 @@ requirements:
     - wheel
   run:
     - python
-    - certifi >=2017.4.17
     - charset-normalizer >=2,<4
     - idna >=2.5,<4
-    - urllib3 >=1.21.1,<2
+    - urllib3 >=1.21.1,<3
+    - certifi >=2017.4.17
   # https://github.com/psf/requests/blob/da9996fe4dc63356e9467d0a5e10df3d89a8528e/requests/__init__.py#L103-L115
   run_constrained:
     - chardet >=3.0.2,<6
-    - pysocks >=1.5.6, !=1.5.7
+    - pysocks >=1.5.6,!=1.5.7
 
 test:
+  imports:
+    - requests
   requires:
     - pip
     - conda                                            # [py<312] temporary for the 3.12 buildout
@@ -42,8 +40,6 @@ test:
     - pip check
     # to make sure this doesn't break conda at the very least
     - conda create -v --dry-run -n requests-test numpy # [py<312] temporary for the 3.12 buildout
-  imports:
-    - requests
 
 about:
   home: https://requests.readthedocs.io/


### PR DESCRIPTION
requests 2.31.0

**Destination channel:** defaults

### Links

- [PKG-4009]
- https://github.com/psf/requests/tree/v2.31.0
- Relevant dependency PRs:
  - AnacondaRecipes/tableauserverclient-feedstock#2

### Explanation of changes:

- This package needs a fix because in our index it requires `urllib3>=1.21.1,<2` instead of the `urllib3 >=1.21.1,<3` [specified in the upstream](https://github.com/psf/requests/blob/147c8511ddbfa5e8f71bbf5c18ede0c4ceb3bba4/setup.py#L61-L66), and [also on pypi](https://inspector.pypi.io/project/requests/2.31.0/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl/requests-2.31.0.dist-info/METADATA#line.35), because [we made a conservative choice here](https://github.com/AnacondaRecipes/requests-feedstock/pull/11#discussion_r1274522216).
- see also comment: https://github.com/AnacondaRecipes/tableauserverclient-feedstock/pull/2#issuecomment-1928165983
- bump build number to `1`.
- add `abs.yaml` for `py312`

[PKG-4009]: https://anaconda.atlassian.net/browse/PKG-4009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ