### PR TITLE
update to 2.32.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
   run_constrained:
     - chardet >=3.0.2,<6
     - pysocks >=1.5.6,!=1.5.7
-    - charset-normalizer >=2.0.0,<4.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "requests" %}
-{% set version = "2.31.0" %}
+{% set version = "2.32.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/requests-{{ version }}.tar.gz
-  sha256: 942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
+  sha256: dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -25,10 +25,11 @@ requirements:
     - idna >=2.5,<4
     - urllib3 >=1.21.1,<3
     - certifi >=2017.4.17
-  # https://github.com/psf/requests/blob/da9996fe4dc63356e9467d0a5e10df3d89a8528e/requests/__init__.py#L103-L115
+  # https://github.com/psf/requests/blob/v2.32.2/src/requests/__init__.py#L58
   run_constrained:
     - chardet >=3.0.2,<6
     - pysocks >=1.5.6,!=1.5.7
+    - charset-normalizer >=2.0.0,<4.0.0
 
 test:
   imports:


### PR DESCRIPTION
requests 2.32.2

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-4826
- https://github.com/psf/requests/tree/v2.32.2
- https://github.com/psf/requests/releases

### Explanation of changes:

- Regular update. There is an assert on charset-normalizer here: https://github.com/psf/requests/blob/v2.32.2/src/requests/__init__.py#L58. Hence the added run_constrained entry.