### PR TITLE
PKG-15087: Update requests to 2.34.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "requests" %}
-{% set version = "2.33.1" %}
+{% set version = "2.34.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517
+  sha256: f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:


### PR DESCRIPTION
## requests 2.34.2

**Destination channel:** defaults

### Links
- [PKG-15087](https://anaconda.atlassian.net/browse/PKG-15087)
- [PyPI](https://pypi.org/project/requests/2.34.2/)
- [GitHub](https://github.com/psf/requests)

### Explanation of changes:
- Updated requests from 2.33.1 to 2.34.2
- Updated Python requirement from `>=3.9` to `>=3.10` (matching upstream)
- No dependency changes

[PKG-15087]: https://anaconda.atlassian.net/browse/PKG-15087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ